### PR TITLE
Add docker setup

### DIFF
--- a/Dockerfile.backend
+++ b/Dockerfile.backend
@@ -1,0 +1,7 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
+EXPOSE 8000
+CMD ["python", "main.py"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,25 @@
 version: '3.8'
 services:
+  backend:
+    build:
+      context: .
+      dockerfile: Dockerfile.backend
+    volumes:
+      - ./config:/app/config
+    ports:
+      - "8000:8000"
+    depends_on:
+      - meilisearch
+
+  frontend:
+    build:
+      context: ./frontend
+      dockerfile: Dockerfile.frontend
+    ports:
+      - "5173:5173"
+    depends_on:
+      - backend
+
   meilisearch:
     image: getmeili/meilisearch:latest
     ports:

--- a/frontend/Dockerfile.frontend
+++ b/frontend/Dockerfile.frontend
@@ -1,0 +1,7 @@
+FROM node:20-alpine
+WORKDIR /app
+COPY package.json package-lock.json* ./
+RUN npm install
+COPY . .
+EXPOSE 5173
+CMD ["npm", "run", "dev", "--", "--host"]

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -7,6 +7,7 @@ import tailwindcss from '@tailwindcss/vite'
 export default defineConfig({
   plugins: [react(), tailwindcss(), basicSsl()],
   server: {
+    host: '0.0.0.0',
     https: true,
     port: 5173,
     proxy: {


### PR DESCRIPTION
## Summary
- add Dockerfiles for backend and frontend
- modify Vite dev server to listen on `0.0.0.0`
- update docker-compose with backend and frontend services

## Testing
- `pip install -r requirements.txt`
- `pip install httpx`
- `pytest -q` *(fails: Meilisearch service not running)*

------
https://chatgpt.com/codex/tasks/task_b_6841b97e215c83228d42f0b5f9b3551f